### PR TITLE
feat: migrate to python dhi image

### DIFF
--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -32,6 +32,8 @@ jobs:
       should-build: ${{ steps.check.outputs.should-build }}
       should-push: ${{ steps.check.outputs.should-push }}
       ref: ${{ steps.check.outputs.ref }}
+      version: ${{ steps.version.outputs.tag }}
+      has-version: ${{ steps.version.outputs.has-version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -90,6 +92,23 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+
+      - name: Extract version from ref
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          ref="${{ steps.check.outputs.ref }}"
+          # Check if ref looks like a version tag (starts with v or is a semver pattern)
+          if [[ "$ref" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            version="${ref#v}"  # Remove leading 'v' if present
+            echo "tag=$version" >> "$GITHUB_OUTPUT"
+            echo "has-version=true" >> "$GITHUB_OUTPUT"
+            echo "📦 Version tag detected: $version"
+          else
+            echo "has-version=false" >> "$GITHUB_OUTPUT"
+            echo "ℹ️  No version tag in ref"
+          fi
 
   build-amd64:
     name: Build amd64 image
@@ -212,12 +231,26 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create and push multi-arch manifests (DockerHub + GHCR)
+        shell: bash
         run: |
+          set -euo pipefail
           # docker buildx imagetools create will assemble a manifest list from existing images
+          version_tag=""
+          if [[ "${{ needs.prepare.outputs.has-version }}" == "true" ]]; then
+            version_tag="--tag ${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}"
+          fi
+
           docker buildx imagetools create --tag "${{ env.IMAGE_NAME }}:latest" \
+            ${version_tag} \
             "${{ env.IMAGE_NAME }}:amd64" \
             "${{ env.IMAGE_NAME }}:arm64"
 
+          version_tag_ghcr=""
+          if [[ "${{ needs.prepare.outputs.has-version }}" == "true" ]]; then
+            version_tag_ghcr="--tag ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.version }}"
+          fi
+
           docker buildx imagetools create --tag "ghcr.io/${{ github.repository }}:latest" \
+            ${version_tag_ghcr} \
             "ghcr.io/${{ github.repository }}:amd64" \
             "ghcr.io/${{ github.repository }}:arm64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,23 +8,32 @@ COPY ./requirements.txt ./
 
 RUN python3 -m pip install -U pip
 
-RUN python3 -m pip install --prefix="/build" -U -r ./requirements.txt
+RUN python3 -m pip install --no-cache-dir --prefix="/build" -U -r ./requirements.txt
 
 FROM base
 
 ENV OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 ENV PYTHONUNBUFFERED=1
 
-RUN apt update && apt full-upgrade -y && \
-    apt install -y git curl sshpass openssh-client jq --no-install-recommends && \
+RUN echo 'path-exclude=/usr/share/doc/*' >> /etc/dpkg/dpkg.cfg.d/01_nodoc && \
+    echo 'path-exclude=/usr/share/man/*' >> /etc/dpkg/dpkg.cfg.d/01_nodoc && \
+    echo 'path-exclude=/usr/share/groff/*' >> /etc/dpkg/dpkg.cfg.d/01_nodoc && \
+    echo 'path-exclude=/usr/share/info/*' >> /etc/dpkg/dpkg.cfg.d/01_nodoc && \
+    apt update && apt full-upgrade --no-install-recommends --no-install-suggests -y && \
+    apt install git curl sshpass openssh-client jq --no-install-recommends --no-install-suggests -y && \
+    apt clean && \
     update-ca-certificates --fresh && \
-    rm -rf /tmp/* /var/tmp/* /var/cache/* && \
+    find /usr/share/locale -mindepth 1 -maxdepth 1 ! -name 'en_US' ! -name 'en_GB' ! -name 'pt_PT' ! -name 'locale.alias' -exec rm -rf {} + && \
+    rm -rf /tmp/* /var/tmp/* /var/cache/apt/* /var/lib/apt/lists/* /usr/share/doc/* /usr/share/man/* /usr/share/groff/* /usr/share/info/* && \
     sync
 
 COPY ./requirements.yml ./
 
-COPY --from=builder /build /usr/local
+COPY --from=builder /build /opt/python
 
-RUN ansible-galaxy collection install -r ./requirements.yml
+RUN ansible-galaxy collection install -r ./requirements.yml &&\
+    find /opt/python -type f \( -name '*.pyc' -o -name '*.pyo' \) -delete &&\
+    find /opt/python -type d -name __pycache__ -delete &&\
+    sync
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim AS base
+FROM dhi.io/python:3.14-dev AS base
 
 FROM base AS builder
 


### PR DESCRIPTION
This pull request introduces significant improvements to the container build pipeline and optimizes the Docker image. The main changes include enhanced version tag handling in the GitHub Actions workflow, a switch to a new Python base image, and multiple optimizations to reduce the Docker image size and improve build efficiency.

**Build workflow enhancements:**

* Added logic in `.github/workflows/build-containers.yaml` to extract version tags from Git references and pass this information through the workflow, enabling conditional tagging of images with version numbers. [[1]](diffhunk://#diff-bd575555d2427663ffea8bd4461aa3c125513e2e8615af7e035108303ddf46dcR96-R112) [[2]](diffhunk://#diff-bd575555d2427663ffea8bd4461aa3c125513e2e8615af7e035108303ddf46dcR35-R36)
* Updated the manifest creation steps to optionally tag images with version numbers if a version tag is detected, ensuring versioned images are pushed to both DockerHub and GHCR.

**Docker image optimizations:**

* Switched the base image in `Dockerfile` from `python:3.13-slim` to `dhi.io/python:3.14-dev`, potentially providing updated dependencies and a more tailored base.
* Improved package installation by disabling cache during pip installs and reducing installed documentation and locales, which significantly shrinks the final image size.
* Changed the installation prefix for Python dependencies from `/usr/local` to `/opt/python` and added cleanup steps to remove unnecessary Python cache files, further reducing image size.